### PR TITLE
fix(lib): update font packaging

### DIFF
--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ledgerhq/crypto-icons",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Crypto icons by Ledger",
   "license": "MIT",
   "main": "dist/index.js",

--- a/lib/rollup.config.mjs
+++ b/lib/rollup.config.mjs
@@ -32,8 +32,8 @@ export default {
     }),
     url({
       include: ['**/*.woff2'],
-      fileName: '[dirname][hash][extname]',
-      emitFiles: 'true',
+      fileName: 'fonts/[name][extname]',
+      emitFiles: true,
       limit: 0,
     }),
   ],


### PR DESCRIPTION
The font was referenced with its original file name in CSS but hashed with Rollup so the path wasn't resolving correctly for consumers e.g.
`GET /fonts/e2489fba31a1d3b5.woff2 404`

This change should fix the issue (tested locally). 

Note that using the name instead of a hash means that we would need to use a different file name if the font needs to be changed in the future as it may be cached by browsers.