### PR TITLE
feat: add network support

### DIFF
--- a/assets/index.json
+++ b/assets/index.json
@@ -600,7 +600,7 @@
     "icon": "XTZ.png"
   },
   "ethereum/erc20/tether_gold": {
-    "icon": "xAUt.png"
+    "icon": "XAUt.png"
   },
   "arbitrum/erc20/wrapped_ether": {
     "icon": "WETH.png"

--- a/lib/__stories__/CryptoIcon.stories.tsx
+++ b/lib/__stories__/CryptoIcon.stories.tsx
@@ -26,6 +26,11 @@ const meta = {
 
 export default meta;
 
+const getNetworkFormLedgerId = (ledgerId: string) => {
+  const ledgerIdSplit = ledgerId.split('/');
+  return ledgerIdSplit.length > 1 ? ledgerIdSplit[0] : undefined;
+};
+
 const Template: StoryFn = ({ theme = 'light' }) => (
   <div style={{ padding: '0.5rem', backgroundColor: theme === 'light' ? '#FFFFFF' : '#1C1D1F' }}>
     {Object.entries(iconsObj).map(([key, value]) => (
@@ -44,12 +49,47 @@ const Template: StoryFn = ({ theme = 'light' }) => (
               marginBottom: '10px',
             }}
           >
-            <CryptoIcon ledgerId={key} ticker={value.icon} size="56px" theme={theme} />
-            <CryptoIcon ledgerId={key} ticker={value.icon} size="48px" theme={theme} />
-            <CryptoIcon ledgerId={key} ticker={value.icon} size="40px" theme={theme} />
-            <CryptoIcon ledgerId={key} ticker={value.icon} size="32px" theme={theme} />
-            <CryptoIcon ledgerId={key} ticker={value.icon} size="24px" theme={theme} />
-            <CryptoIcon ledgerId={key} ticker={value.icon} theme={theme} />
+            <CryptoIcon
+              ledgerId={key}
+              ticker={value.icon}
+              size="56px"
+              theme={theme}
+              network={getNetworkFormLedgerId(key)}
+            />
+            <CryptoIcon
+              ledgerId={key}
+              ticker={value.icon}
+              size="48px"
+              theme={theme}
+              network={getNetworkFormLedgerId(key)}
+            />
+            <CryptoIcon
+              ledgerId={key}
+              ticker={value.icon}
+              size="40px"
+              theme={theme}
+              network={getNetworkFormLedgerId(key)}
+            />
+            <CryptoIcon
+              ledgerId={key}
+              ticker={value.icon}
+              size="32px"
+              theme={theme}
+              network={getNetworkFormLedgerId(key)}
+            />
+            <CryptoIcon
+              ledgerId={key}
+              ticker={value.icon}
+              size="24px"
+              theme={theme}
+              network={getNetworkFormLedgerId(key)}
+            />
+            <CryptoIcon
+              ledgerId={key}
+              ticker={value.icon}
+              theme={theme}
+              network={getNetworkFormLedgerId(key)}
+            />
           </div>
           <div
             style={{

--- a/lib/src/components/CryptoIcon/CryptoIcon.tsx
+++ b/lib/src/components/CryptoIcon/CryptoIcon.tsx
@@ -2,23 +2,45 @@ import React, { FC, useEffect, useState } from 'react';
 import styled from 'styled-components';
 import { getIconUrl } from '../../iconMapping';
 import FallbackIcon from '../FallbackIcon/FallbackIcon';
-import IconWrapper from '../IconWrapper/IconWrapper';
+import IconWrapper, { RoundedIcon } from '../IconWrapper/IconWrapper';
 import { CryptoIconProps } from './CryptoIcon.types';
 
-const Icon = styled.img`
+const Icon = styled(RoundedIcon)<{ hasNetwork: boolean }>`
   height: 100%;
   width: 100%;
+  ${({ hasNetwork }) =>
+    hasNetwork
+      ? 'mask-image: radial-gradient(circle closest-side at 81.5% 81.5%, transparent 125%, white 130%);'
+      : ''}
 `;
 
-const CryptoIcon: FC<CryptoIconProps> = ({ ledgerId, ticker, size = '16px', theme }) => {
+const NetworkIcon = styled(RoundedIcon)<Pick<CryptoIconProps, 'size'>>`
+  height: calc(${({ size }) => size} / 2.8);
+  width: calc(${({ size }) => size} / 2.8);
+  position: absolute;
+  right: 0px;
+  bottom: 0px;
+`;
+
+const CryptoIcon: FC<CryptoIconProps> = ({
+  ledgerId,
+  ticker,
+  size = '16px',
+  theme = 'dark',
+  network,
+}) => {
   const [iconUrl, setIconUrl] = useState<string | null>(null);
+  const [networkUrl, setNetworkUrl] = useState<string | null>(null);
   const [loading, setLoading] = useState<boolean>(true);
 
   useEffect(() => {
     const loadIcon = async () => {
+      const iconsToResolve = [getIconUrl(ledgerId)];
+      if (network) iconsToResolve.push(getIconUrl(network));
       try {
-        const url = await getIconUrl(ledgerId);
+        const [url, networkUrlResolved] = await Promise.all(iconsToResolve);
         setIconUrl(url);
+        if (network && networkUrlResolved) setNetworkUrl(networkUrlResolved);
       } catch (e) {
         console.error(e);
       } finally {
@@ -27,13 +49,18 @@ const CryptoIcon: FC<CryptoIconProps> = ({ ledgerId, ticker, size = '16px', them
     };
 
     loadIcon();
-  }, [ledgerId]);
+  }, [network, ledgerId]);
 
   if (loading) return null;
 
   return (
     <IconWrapper size={size} theme={theme}>
-      {iconUrl ? <Icon src={iconUrl} alt={ticker} /> : <FallbackIcon ticker={ticker} size={size} />}
+      {iconUrl ? (
+        <Icon theme={theme} src={iconUrl} alt={ticker} hasNetwork={!!networkUrl} />
+      ) : (
+        <FallbackIcon ticker={ticker} size={size} />
+      )}
+      {networkUrl ? <NetworkIcon theme={theme} src={networkUrl} size={size} /> : null}
     </IconWrapper>
   );
 };

--- a/lib/src/components/CryptoIcon/CryptoIcon.types.ts
+++ b/lib/src/components/CryptoIcon/CryptoIcon.types.ts
@@ -6,4 +6,5 @@ export type CryptoIconProps = {
   ticker: Currency['ticker'];
   theme?: ThemeNames;
   size?: '16px' | '24px' | '32px' | '40px' | '48px' | '56px';
+  network?: Currency['id'];
 };

--- a/lib/src/components/FallbackIcon/FallbackIcon.tsx
+++ b/lib/src/components/FallbackIcon/FallbackIcon.tsx
@@ -29,20 +29,26 @@ const Icon = styled.div<Partial<FallbackIconProps>>`
   display: flex;
   align-items: center;
   justify-content: center;
-  background-color: #757575;
   color: #ffffff;
   font-weight: 700;
   font-size: ${({ size }) => iconSizeToFontSize[size!]};
   font-family: 'Inter', sans-serif;
 `;
 
+const IconWrapper = styled.div`
+  height: 100%;
+  width: 100%;
+  border-radius: 50%;
+  background-color: #757575;
+`;
+
 const FallbackIcon: FC<FallbackIconProps> = ({ ticker, size }) => (
-  <>
+  <IconWrapper>
     <InterBoldFont />
     <Icon size={size} role="img">
       {ticker[0]}
     </Icon>
-  </>
+  </IconWrapper>
 );
 
 export default FallbackIcon;

--- a/lib/src/components/IconWrapper/IconWrapper.tsx
+++ b/lib/src/components/IconWrapper/IconWrapper.tsx
@@ -11,16 +11,22 @@ const Wrapper = styled.div<IconWrapperProps>`
   height: ${({ size }) => size};
   width: ${({ size }) => size};
   overflow: hidden;
-  border: 1px solid;
+  position: relative;
+`;
+
+export const RoundedIcon = styled.img<Pick<CryptoIconProps, 'theme'>>`
   border-radius: 50%;
-  border-color: ${({ theme }: { theme: 'dark' | 'light' }) => palettes[theme].opacityDefault.c05};
   display: flex;
   align-items: center;
   justify-content: center;
   box-sizing: border-box;
+  outline: 1px auto ${({ theme }: { theme: 'dark' | 'light' }) => palettes[theme].opacityDefault.c05};
+  outline-offset: -1px;
+  outline-style: solid;
+}
 `;
 
-const IconWrapper: FC<IconWrapperProps> = ({ children, size, theme = 'dark' }) => (
+const IconWrapper: FC<IconWrapperProps> = ({ children, size, theme }) => (
   <Wrapper size={size} theme={theme}>
     {children}
   </Wrapper>


### PR DESCRIPTION
Add support for network
To display the network you need to add the network ledgerId as following:
```
  <CryptoIcon
    ledgerId={key}
    ticker={value.icon}
    size="48px"
    theme={theme}
    network={getNetworkFormLedgerId(key)}
  />
```
<img width="377" alt="image" src="https://github.com/user-attachments/assets/f3a9ce8f-ceaf-4d0f-9b7d-9b1e29809694">
<img width="369" alt="image" src="https://github.com/user-attachments/assets/98772b67-238d-4ae6-abbc-009c003e4c66">
