### PR TITLE
fix: remove error log

### DIFF
--- a/lib/package.json
+++ b/lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ledgerhq/crypto-icons",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Crypto icons by Ledger",
   "license": "MIT",
   "main": "dist/index.js",

--- a/lib/src/iconMapping.ts
+++ b/lib/src/iconMapping.ts
@@ -46,8 +46,7 @@ const setLedgerIconMapping = async () => {
       ledgerMapping = data;
       return ledgerMapping;
     })
-    .catch((e) => {
-      console.error(e);
+    .catch(() => {
       return null;
     })
     .finally(() => {
@@ -73,8 +72,7 @@ const setCoinGeckoIconMapping = async () => {
       coinGeckoMapping = data;
       return coinGeckoMapping;
     })
-    .catch((e) => {
-      console.error(e);
+    .catch(() => {
       return null;
     })
     .finally(() => {


### PR DESCRIPTION
Removing `console.error` on failed requests to prevent issues with async logging in consumer Jest tests. 

![jest-err](https://github.com/user-attachments/assets/86c58cfb-f522-4e67-85c9-494339e98832)


Verified this change by adding the packaged lib locally into a project and running tests in the pipeline: https://github.com/LedgerHQ/buy-sell-ui/pull/395