### PR TITLE
fix(lib): add loading skeleton to prevent content shift

### DIFF
--- a/lib/src/components/CryptoIcon/CryptoIcon.tsx
+++ b/lib/src/components/CryptoIcon/CryptoIcon.tsx
@@ -2,7 +2,7 @@ import React, { FC, useEffect, useState } from 'react';
 import styled from 'styled-components';
 import { getIconUrl } from '../../iconMapping';
 import FallbackIcon from '../FallbackIcon/FallbackIcon';
-import IconWrapper, { RoundedIcon } from '../IconWrapper/IconWrapper';
+import IconWrapper, { RoundedIcon, Skeleton } from '../IconWrapper/IconWrapper';
 import { CryptoIconProps } from './CryptoIcon.types';
 
 const Icon = styled(RoundedIcon)<{ hasNetwork: boolean }>`
@@ -52,7 +52,7 @@ const CryptoIcon: FC<CryptoIconProps> = ({
     loadIcon();
   }, [network, ledgerId]);
 
-  if (loading) return null;
+  if (loading) return <Skeleton size={size} theme={theme} />;
 
   return (
     <IconWrapper size={size} theme={theme}>

--- a/lib/src/components/IconWrapper/IconWrapper.tsx
+++ b/lib/src/components/IconWrapper/IconWrapper.tsx
@@ -26,6 +26,14 @@ export const RoundedIcon = styled.img<Pick<CryptoIconProps, 'theme'>>`
 }
 `;
 
+export const Skeleton = styled.div<Pick<CryptoIconProps, 'size' | 'theme'>>`
+  height: ${({ size }) => size};
+  width: ${({ size }) => size};
+  border-radius: 50%;
+  background-color: ${({ theme }: { theme: 'dark' | 'light' }) =>
+    palettes[theme].opacityDefault.c05};
+`;
+
 const IconWrapper: FC<IconWrapperProps> = ({ children, size, theme }) => (
   <Wrapper size={size} theme={theme}>
     {children}


### PR DESCRIPTION
Returning a skeleton component while loading is true to prevent content shift.
https://ledgerhq.atlassian.net/browse/LIVE-13929

| Main | This PR (light mode) | This PR (dark mode |
| ----- | ----- | ----- |
| ![main](https://github.com/user-attachments/assets/34bb9967-24b7-4902-913c-27eed4cd91b3) | ![light-mode](https://github.com/user-attachments/assets/3b923877-2e63-4f31-ae8a-577e862fcab9) | ![dark-mode](https://github.com/user-attachments/assets/cfd9ffe1-949c-4bed-9475-bf63a7cef2dd) |