### PR TITLE
feat(ci): weekly icon coverage tracker

### DIFF
--- a/.github/scripts/check-icon-coverage.mjs
+++ b/.github/scripts/check-icon-coverage.mjs
@@ -1,0 +1,54 @@
+const ASSETS_URL =
+  'https://dada.api.ledger.com/v1/assets?pageSize=100&sortOrder=desc&sortKey=marketCap';
+const INDEX_URL = 'https://crypto-icons.ledger.com/index.json';
+
+async function main() {
+  const [assetsRes, indexRes] = await Promise.all([fetch(ASSETS_URL), fetch(INDEX_URL)]);
+
+  if (!assetsRes.ok) throw new Error(`Assets API: ${assetsRes.status}`);
+  if (!indexRes.ok) throw new Error(`index.json: ${indexRes.status}`);
+
+  const assets = await assetsRes.json();
+  const index = await indexRes.json();
+
+  const rankedIds = assets.currenciesOrder?.currenciesIds ?? [];
+  const mappedIds = new Set(Object.keys(index));
+
+  const missing = rankedIds.filter((id) => !mappedIds.has(id));
+  const covered = rankedIds.length - missing.length;
+
+  // Build a ledgerId → { name, ticker } lookup from the assets response
+  const idToInfo = {};
+  for (const asset of Object.values(assets.cryptoAssets ?? {})) {
+    for (const ledgerId of Object.values(asset.assetsIds ?? {})) {
+      idToInfo[ledgerId] = { name: asset.name ?? 'N/A', ticker: asset.ticker ?? 'N/A' };
+    }
+  }
+
+  const date = new Date().toISOString().split('T')[0];
+  const rows = missing.map((id) => {
+    const { name, ticker } = idToInfo[id] ?? { name: 'N/A', ticker: 'N/A' };
+    return `| ${ticker} | ${name} | \`${id}\` |`;
+  });
+
+  const body = [
+    `## Icon Coverage Report`,
+    ``,
+    `> Last updated: **${date}** — [assets API](${ASSETS_URL}) vs [\`index.json\`](${INDEX_URL})`,
+    ``,
+    `**${covered} / ${rankedIds.length}** ranked ledger IDs are covered in \`index.json\`.`,
+    ``,
+    `### ❌ Missing (${missing.length})`,
+    ``,
+    `| Ticker | Name | Ledger ID |`,
+    `| ------ | ---- | --------- |`,
+    ...rows,
+  ].join('\n');
+
+  process.stdout.write(body);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/.github/workflows/icon-coverage.yml
+++ b/.github/workflows/icon-coverage.yml
@@ -1,0 +1,51 @@
+name: Icon Coverage Tracker
+
+on:
+  schedule:
+    - cron: "0 9 * * 1" # Every Monday at 9am UTC
+  workflow_dispatch:
+
+jobs:
+  check-coverage:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Run coverage check
+        run: node .github/scripts/check-icon-coverage.mjs > /tmp/coverage-report.md
+
+      - name: Ensure label exists
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh label create "icon-coverage" \
+            --description "Weekly icon coverage tracking" \
+            --color "0052cc" \
+            --force 2>/dev/null || true
+
+      - name: Create or update coverage issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          ISSUE_NUMBER=$(gh issue list \
+            --label "icon-coverage" \
+            --state open \
+            --json number \
+            --jq '.[0].number // empty')
+
+          if [ -z "$ISSUE_NUMBER" ]; then
+            gh issue create \
+              --title "Icon Coverage Tracker: missing ledger IDs in index.json" \
+              --body-file /tmp/coverage-report.md \
+              --label "icon-coverage"
+          else
+            gh issue edit "$ISSUE_NUMBER" \
+              --body-file /tmp/coverage-report.md
+          fi


### PR DESCRIPTION
## Summary

- Adds a GitHub Actions workflow that runs every Monday at 9am UTC (+ manual `workflow_dispatch`)
- Fetches ranked ledger IDs from the Ledger assets API and compares them against `index.json`
- Creates a GitHub issue on first run, then **edits its body** on subsequent runs to keep a single up-to-date tracker

## Files

- `.github/workflows/icon-coverage.yml` — cron workflow
- `.github/scripts/check-icon-coverage.mjs` — fetch + diff script (plain Node 20, no deps)

## Test plan

- [ ] Trigger manually via Actions → "Icon Coverage Tracker" → Run workflow
- [ ] Verify an issue is created with the `icon-coverage` label and a markdown table of missing IDs
- [ ] Re-run and verify the same issue body is updated, not a new issue created
- [ ] Check repo Settings → Actions → General → Workflow permissions has `issues: write` enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)