### PR TITLE
ci: migrate to newest attestation functions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -39,19 +39,17 @@ jobs:
       - name: Build project
         run: pnpm run build
 
-      - name: Create tarball for attestation
-        run: |
-          echo "TARBALL=$(pnpm pack --pack-destination dist)" >> $GITHUB_ENV
-
-      - name: Attest tarball
-        uses: LedgerHQ/actions-security/actions/attest@actions/attest-1
+      - name: Attest for npmjs.com
+        id: attest
+        uses: LedgerHQ/actions-security/actions/attest-for-npmsjs-com@actions/attest-for-npmsjs-com-0.1.2
         with:
-          subject-path: ./lib/dist
+          subject-path: lib
+          package-manager: npm
 
       - name: Sign tarball
         uses: LedgerHQ/actions-security/actions/sign-blob@actions/sign-blob-1
         with:
-          path: ./lib/dist
+          path: ${{ steps.attest.outputs.tarball-path }}
 
       - name: Login to JFrog Ledger
         id: jfrog-login
@@ -67,4 +65,4 @@ jobs:
           EOF
 
       - name: Publish package to JFrog
-        run: pnpm publish $TARBALL --no-git-checks
+        run: pnpm publish "${{ steps.attest.outputs.tarball-path }}" --no-git-checks

--- a/lib/package.json
+++ b/lib/package.json
@@ -1,8 +1,12 @@
 {
   "name": "@ledgerhq/crypto-icons",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Crypto icons by Ledger",
   "license": "MIT",
+  "repository": { 
+    "type": "git", 
+    "url": "https://github.com/LedgerHQ/crypto-icons" 
+  },
   "main": "dist/index.js",
   "module": "dist/index.esm.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
Re-publish current crypto icons under a different version number to solve jFrog checksum mismatch

Test run: https://github.com/LedgerHQ/crypto-icons/actions/runs/25742890047