### PR TITLE
:bug: fix icon coverage tracker against new dada API shape

### DIFF
--- a/.github/scripts/check-icon-coverage.mjs
+++ b/.github/scripts/check-icon-coverage.mjs
@@ -11,19 +11,29 @@ async function main() {
   const assets = await assetsRes.json();
   const index = await indexRes.json();
 
-  const rankedIds = assets.currenciesOrder?.currenciesIds ?? [];
-  const mappedIds = new Set(Object.keys(index));
+  const cryptoAssets = assets.cryptoAssets ?? {};
+  const metaCurrencyIds = assets.currenciesOrder?.metaCurrencyIds ?? [];
 
-  const missing = rankedIds.filter((id) => !mappedIds.has(id));
-  const covered = rankedIds.length - missing.length;
-
-  // Build a ledgerId → { name, ticker } lookup from the assets response
+  // Build a ledgerId → { name, ticker } lookup, and expand the ranked
+  // meta-currency list into its underlying ledger IDs (preserving rank order).
   const idToInfo = {};
-  for (const asset of Object.values(assets.cryptoAssets ?? {})) {
+  const rankedIds = [];
+  const seen = new Set();
+  for (const metaId of metaCurrencyIds) {
+    const asset = cryptoAssets[metaId];
+    if (!asset) continue;
     for (const ledgerId of Object.values(asset.assetsIds ?? {})) {
       idToInfo[ledgerId] = { name: asset.name ?? 'N/A', ticker: asset.ticker ?? 'N/A' };
+      if (!seen.has(ledgerId)) {
+        seen.add(ledgerId);
+        rankedIds.push(ledgerId);
+      }
     }
   }
+
+  const mappedIds = new Set(Object.keys(index));
+  const missing = rankedIds.filter((id) => !mappedIds.has(id));
+  const covered = rankedIds.length - missing.length;
 
   const date = new Date().toISOString().split('T')[0];
   const rows = missing.map((id) => {


### PR DESCRIPTION
## Summary
- \`dada /v1/assets\` is deprecating \`currenciesOrder.currenciesIds\` (already returned as \`[]\`, full removal in a later release). That field was the only input to the weekly Icon Coverage Tracker, so issue #104 was generated with \`0 / 0\` coverage and an empty missing table.
- Per the dada team, the ranked list should be reconstructed from \`currenciesOrder.metaCurrencyIds\` plus each meta-currency's \`assetsIds\` map. The script now iterates \`metaCurrencyIds\`, expands each to its underlying ledger IDs (deduped, rank-ordered), and checks them against \`index.json\`.



## Test plan
- [x] Run \`node .github/scripts/check-icon-coverage.mjs\` locally — output now reports \`400 / 410\` covered with 10 missing entries (USDtb, JTRSY, FBTC variants).
- [ ] Trigger the \`Icon Coverage Tracker\` workflow via \`workflow_dispatch\` after merge and confirm issue #104 is updated with a non-empty report. https://github.com/LedgerHQ/crypto-icons/actions/runs/26052586168