### PR TITLE
chore: add npm package metadata links

### DIFF
--- a/lib/package.json
+++ b/lib/package.json
@@ -7,6 +7,10 @@
     "type": "git",
     "url": "https://github.com/LedgerHQ/crypto-icons"
   },
+  "homepage": "https://github.com/LedgerHQ/crypto-icons#readme",
+  "bugs": {
+    "url": "https://github.com/LedgerHQ/crypto-icons/issues"
+  },
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Summary
- add a package homepage that points to the repository README
- add npm-standard `bugs.url` metadata for the GitHub issue tracker

## Verification
- `node -e "const p=require('./lib/package.json'); console.log(JSON.stringify({name:p.name,version:p.version,homepage:p.homepage,bugs:p.bugs}, null, 2))"`
- `npm pack --dry-run --json --ignore-scripts` from `lib/`

This is metadata-only and does not change runtime code.