### PR TITLE
feat: add hypercore to HYPE icon

### DIFF
--- a/assets/_record.json
+++ b/assets/_record.json
@@ -647,7 +647,7 @@
     "ids": ["ethereum/erc20/htx", "bsc/bep20/htx"]
   },
   "HYPE": {
-    "ids": ["hyperevm"]
+    "ids": ["hyperevm", "hypercore"]
   },
   "ETH_Testnet": {
     "ids": ["ethereum_hoodi", "ethereum_sepolia", "ethereum_holesky"]

--- a/assets/index.json
+++ b/assets/index.json
@@ -1706,6 +1706,9 @@
   "hive": {
     "icon": "HIVE.png"
   },
+  "hypercore": {
+    "icon": "HYPE.png"
+  },
   "hyperevm": {
     "icon": "HYPE.png"
   },


### PR DESCRIPTION
## Summary
Add hypercore to existing HYPE icon

## Checklist
- [ ] 144×144 PNG
- [ ] Compressed with zopflipng (≤ 50 KB)
- [x] `_record.json` updated (alphabetical order)
- [x] `index.json` regenerated
